### PR TITLE
Tokens can be dragged onto the board again

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -121,7 +121,7 @@ io.on('connection', (socket) => {
 
   socket.on('PLACE_TOKEN', (cell, token, username, room) => {
     // tokens.push({cell: cell, token: token, username: username});
-    io.to(room).emit('PLACE_TOKEN', cell, token, username);
+    io.emit('PLACE_TOKEN', cell, token, username, room);
   });
 
   socket.on('REMOVE_TOKEN', (cell, room) => {

--- a/server/server.js
+++ b/server/server.js
@@ -124,8 +124,12 @@ io.on('connection', (socket) => {
     io.emit('PLACE_TOKEN', cell, token, username, room);
   });
 
+  socket.on('REMOVE_OCCUPIED_TOKEN_SPACE', (lastPosX, lastPosY, size, room) => {
+    io.emit('REMOVE_OCCUPIED_TOKEN_SPACE', lastPosX, lastPosY, size, room);
+  });
+
   socket.on('REMOVE_TOKEN', (cell, room) => {
-    io.to(room).emit('REMOVE_TOKEN', cell);
+    io.emit('REMOVE_TOKEN', cell, room);
   });
 
   socket.on('SELECT_MAP', (e, map) => {

--- a/src/components/grid.ts
+++ b/src/components/grid.ts
@@ -5,6 +5,7 @@ import { bindEventsToGrid } from '../scripts/gridInput';
 import { io, Socket } from "socket.io-client";
 import { placeToken, resetTokenBodyData } from './tokensMenu';
 import { getUser } from '../controllers/userController';
+
 const socket: Socket = io();
 
 class Token {
@@ -158,10 +159,9 @@ const socketPlaceToken = (coords: Coord, tokenData: Token, username: string, roo
     socket.emit('PLACE_TOKEN', coords, tokenData, username, room);
 };
 
-
 // Add a token to the board
-socket.on('PLACE_TOKEN', ((selectedCell, menuToken, username) => {
-    console.log(selectedCell, menuToken, username);
+socket.on('PLACE_TOKEN', ((selectedCell, menuToken, username, _room) => {
+    if (room !== _room) return;
     
     const { x, y } = selectedCell;
     const { img, relative, size } = menuToken;

--- a/src/components/grid.ts
+++ b/src/components/grid.ts
@@ -62,7 +62,14 @@ const addGridEvents = (grid: HTMLElement) => {
 
     document.addEventListener('dragend', () => {
         const relativeCell: Element = findRelativeCell(selectedCell, mousePos.x, mousePos.y);
-        addTokenToBoard(relativeCell || <Element>selectedCell);
+        const menuToken = document.querySelector('.token--dragging');
+        
+        // If this is token is being dragged out from the menu, then place it exactly where the mouse cursor is.
+        if (menuToken.classList.contains('menu__item')) {
+            addTokenToBoard(<Element>selectedCell);
+        } else {
+            addTokenToBoard(relativeCell || <Element>selectedCell);
+        }
     });
 };
 
@@ -86,9 +93,9 @@ const addTokenEvents = (token: any, relative: string) => {
     });
     // Handle token moved
     token.addEventListener('dragend', () => {
-        // socket.emit('REMOVE_TOKEN', lastPos, room);
+        socket.emit('REMOVE_TOKEN', lastPos, room);
         const size = parseInt(token.getAttribute('size'));
-        // socket.emit('REMOVE_OCCUPIED_TOKEN_SPACE', lastPos.x, lastPos.y, size, room);
+        socket.emit('REMOVE_OCCUPIED_TOKEN_SPACE', lastPos.x, lastPos.y, size, room);
     });
 };
 
@@ -188,6 +195,23 @@ socket.on('PLACE_TOKEN', ((selectedCell, menuToken, username, _room) => {
 
     addTokenEvents(token, relative);
     resetTokenBodyData();
+}));
+
+// Removes the token background for everyone
+socket.on('REMOVE_OCCUPIED_TOKEN_SPACE', (lastPosX, lastPosY, size, _room) => {
+    if (room !== _room) return;
+
+    if (size > 1) {
+        removeOccupyTokenSpace(lastPosX, lastPosY, size);
+    } else {
+        findCell(lastPosX, lastPosY).style.removeProperty('background-color');
+    }
+});
+
+socket.on('REMOVE_TOKEN', ((cell, _room) => {
+    if (room !== _room) return;
+    const newCell = findCell(cell.x, cell.y);
+    newCell.innerHTML = '';
 }));
 
 

--- a/src/components/grid.ts
+++ b/src/components/grid.ts
@@ -68,10 +68,10 @@ const addGridEvents = (grid: HTMLElement) => {
 
 const addTokenEvents = (token: any, relative: string) => {
     // Open stats menu after double click
-    token.addEventListener('dblclick', () => {
-        if (!relative) return;
-        // openCreatureStatsWindow(relative);
-    });
+    // token.addEventListener('dblclick', () => {
+    //     if (!relative) return;
+    //     openCreatureStatsWindow(relative);
+    // });
     // Handle dragging token
     token.addEventListener('dragstart', (e: any) => {
         const tokenPos = token.getBoundingClientRect();
@@ -80,15 +80,15 @@ const addTokenEvents = (token: any, relative: string) => {
             y: e.y - tokenPos.y
         };
 
-        placeToken(e, parseInt(token.getAttribute('size')));
+        placeToken(token, parseInt(token.getAttribute('size')));
         const cell = token.parentNode;
         lastPos = {x: parseInt(cell.getAttribute('x')), y: parseInt(cell.getAttribute('y'))};
     });
     // Handle token moved
     token.addEventListener('dragend', () => {
-        socket.emit('REMOVE_TOKEN', lastPos, room);
+        // socket.emit('REMOVE_TOKEN', lastPos, room);
         const size = parseInt(token.getAttribute('size'));
-        socket.emit('REMOVE_OCCUPIED_TOKEN_SPACE', lastPos.x, lastPos.y, size, room);
+        // socket.emit('REMOVE_OCCUPIED_TOKEN_SPACE', lastPos.x, lastPos.y, size, room);
     });
 };
 
@@ -164,11 +164,11 @@ socket.on('PLACE_TOKEN', ((selectedCell, menuToken, username, _room) => {
     if (room !== _room) return;
     
     const { x, y } = selectedCell;
-    const { img, relative, size } = menuToken;
+    const { image, relative, size } = menuToken;
     const token = document.createElement('img');
     const cell = findCell(x, y);
     token.classList.add('token');
-    token.setAttribute('src', img);
+    token.setAttribute('src', image);
     token.setAttribute('relative', relative)
     token.setAttribute('user', username);
     token.setAttribute('size', size);

--- a/src/components/tokensMenu.ts
+++ b/src/components/tokensMenu.ts
@@ -58,7 +58,7 @@ const getTokenBodyData = async () => {
     });
 };
 
-export const placeToken = (token: any, size: number) => {    
+export const placeToken = (token: any, size: number) => {
     token.classList.add('token--dragging');
     token.setAttribute('size', size);
 };

--- a/src/components/tokensMenu.ts
+++ b/src/components/tokensMenu.ts
@@ -62,3 +62,20 @@ export const placeToken = (token: any, size: number) => {
     token.classList.add('token--dragging');
     token.setAttribute('size', size);
 };
+
+export const resetTokenBodyData = () => {
+    let deleteList = [];
+    for (let token of Array.from(document.getElementsByClassName('menu__item'))) {
+        deleteList.push(token);
+    }
+    for (let btn of Array.from(document.getElementsByClassName('menu__item--circle-btn'))) {
+        deleteList.push(btn);
+    }
+    for (let box of Array.from(document.getElementsByClassName('menu__body--container'))) {
+        deleteList.push(box);
+    }
+    for (let el of deleteList) {
+        el.remove();
+    }
+    getTokenBodyData();
+};

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -8,6 +8,7 @@
 @import './toolbar';
 @import './menus';
 @import './modal';
+@import './token';
 
 :root {
   /* Main */

--- a/src/styles/token.scss
+++ b/src/styles/token.scss
@@ -1,0 +1,25 @@
+.token {
+    height: var(--size);
+	width: var(--size);
+	grid-area: var(--row) / var(--column);
+    border-radius: 50%;
+    position: absolute;
+    z-index: 1;
+
+    &:hover {
+        cursor: grab;
+    }
+    
+    &--dragging {
+        opacity: 60%;
+    }
+    
+    &--dragging-cursor {
+        cursor: grabbing;
+    }
+    
+    &--selected {
+        border: 3px solid var(--token-selected-color);
+        border-radius: 50%;
+    }
+}


### PR DESCRIPTION
### Description:
Redo the functionality for tokens and the grid, but with typescript.

### Spec:

See Story: [FSA22V2-185](https://sparkbox.atlassian.net/jira/software/c/projects/FSA22V2/boards/125/backlog?view=detail&selectedIssue=FSA22V2-185&quickFilter=209&issueLimit=100)

#### To Validate:

1. Pull down all related branches.
2. `npm run dev`, `npm run sass`, and `npm run tsc` in different terminal windows.
3. run `npm run docker:setup` if you have not done so before. Also follow create a .env file as shown in the readme.
4. Go to [localhost:3000/login](http://localhost:3000/login) to login or register an account.
5. Create a new campaign and start it (Might have to refresh page). You just started the game as the "Dungeon Master"(or DM for short).
6. Copy the room code at the top of the screen.
7. In a new tab to go [localhost:3000/game](http://localhost:3000/game) for the second player. It doesn't matter if it uses the same account.
8. Join the room with the room code. You just joined the game as a player.
9. On the DM screen you should be able to open the tokens menu and drag a token onto the board. The orange buttons on the tokens don't do anything at the moment.
10. If you go back to the player screen, the token should also appear there as well.
11. Verify that you can move the token on either screen and the position will be consistant.